### PR TITLE
updated repos in fabfile.py

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -95,7 +95,7 @@ def deploy_dev_docs():
 def deploy_dev_web():
     local("virtualenv --no-site-packages web_proj/")
     with prefix(". web_proj/bin/activate"):
-        local("git clone git://github.com/requirements/abztrakt/spacescout_web.git web_proj/spacescout_web")
+        local("git clone git://github.com/uw-it-aca/spacescout_web.git web_proj/spacescout_web")
         local("pip install -r web_proj/spacescout_web/base-requirements.txt")
         local("cp configs/dev/web_local_settings.py web_proj/web_proj/local_settings.py")
         local("cp web_proj/web_proj/sample.wsgi.py web_proj/web_proj/wsgi.py")

--- a/fabfile.py
+++ b/fabfile.py
@@ -42,8 +42,8 @@ def deploy_dev():
 def deploy_dev_server():
     local("virtualenv --no-site-packages server_proj/")
     with prefix(". server_proj/bin/activate"):
-        local("git clone git://github.com/abztrakt/spotseeker_server.git server_proj/spotseeker_server")
-        local("pip install -r server_proj/spotseeker_server/requirements.txt")
+        local("git clone git://github.com/uw-it-aca/spotseeker_server.git server_proj/spotseeker_server")
+        local("pip install -r server_proj/spotseeker_server/requirements/requirements.txt")
         local("cp configs/dev/server_local_settings.py server_proj/server_proj/local_settings.py")
         local("cp server_proj/server_proj/sample.wsgi.py server_proj/server_proj/wsgi.py")
         _replace_local_settings_for("server_proj")
@@ -55,7 +55,7 @@ def deploy_dev_server():
 def deploy_dev_admin():
     local("virtualenv --no-site-packages admin_proj/")
     with prefix(". admin_proj/bin/activate"):
-        local("git clone git://github.com/abztrakt/spacescout_admin.git admin_proj/spacescout_admin")
+        local("git clone git://github.com/uw-it-aca/spacescout_admin.git admin_proj/spacescout_admin")
         local("pip install -r admin_proj/spacescout_admin/requirements.txt")
         local("cp configs/dev/admin_local_settings.py admin_proj/admin_proj/local_settings.py")
         _replace_local_settings_for("admin_proj")
@@ -95,8 +95,8 @@ def deploy_dev_docs():
 def deploy_dev_web():
     local("virtualenv --no-site-packages web_proj/")
     with prefix(". web_proj/bin/activate"):
-        local("git clone git://github.com/abztrakt/spacescout_web.git web_proj/spacescout_web")
-        local("pip install -r web_proj/spacescout_web/requirements.txt")
+        local("git clone git://github.com/requirements/abztrakt/spacescout_web.git web_proj/spacescout_web")
+        local("pip install -r web_proj/spacescout_web/base-requirements.txt")
         local("cp configs/dev/web_local_settings.py web_proj/web_proj/local_settings.py")
         local("cp web_proj/web_proj/sample.wsgi.py web_proj/web_proj/wsgi.py")
         _replace_local_settings_for("web_proj")


### PR DESCRIPTION
fabfile.py seems to work fine for setting up and destroying dev environments but the repos weren't pointing to the correct uw-it-aca ones and some of the requirements.txt file paths were incorrect.
